### PR TITLE
MHP-3683: Remove MissionHub references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# MissionHub Web App
+# Campus Contacts Web App
 
-[![Build Status](https://travis-ci.org/CruGlobal/missionhub-web.svg?branch=master)](https://travis-ci.org/CruGlobal/missionhub-web) [![codecov](https://codecov.io/gh/CruGlobal/missionhub-web/branch/master/graph/badge.svg)](https://codecov.io/gh/CruGlobal/missionhub-web)
-[missionhub.com](https://www.missionhub.com) | [stage.missionhub.com](https://stage.missionhub.com)
+[![Build Status](https://travis-ci.com/CruGlobal/campus-contacts-web.svg?branch=master)](https://travis-ci.com/CruGlobal/campus-contacts-web) [![codecov](https://codecov.io/gh/CruGlobal/campus-contacts-web/branch/master/graph/badge.svg)](https://codecov.io/gh/CruGlobal/campus-contacts-web)
+[campuscontacts.cru.org](https://campuscontacts.cru.org) | [stage.campuscontacts.cru.org](https://stage.campuscontacts.cru.org) | [ccontacts.app/](https://ccontacts.app/) | [stage.ccontacts.app/](https://stage.ccontacts.app/)
 
 ## Development
 
@@ -17,7 +17,7 @@ Use yarn for faster installs and to update the yarn lock file: https://yarnpkg.c
 ### Development Tasks
 Note: you may replace `yarn` with `npm` if you aren't using `yarn`
 - `yarn start` to start the webpack dev server for this repo
-- `yarn start-rails-api` to start the rails api server (looks in `../missionhub-api`)
+- `yarn start-rails-api` to start the rails api server (looks in `../campus-contacts-api`)
 - `yarn build` to generate minified output files. These files are output to `/dist`.
 - `yarn build:analyze` to open a visualization of bundle sizes after building
 - `yarn test` to run karma tests once
@@ -26,7 +26,7 @@ Note: you may replace `yarn` with `npm` if you aren't using `yarn`
 - `yarn lint` to run eslint and lint the app's JS files
 
 ### Environment Config
-By default running this repo locally hits the stage API server. If you need to test against the local API, you can edit [missionhubApp.config.js](https://github.com/CruGlobal/missionhub-web/blob/6619d9325424bca3381c2187d3ad2d73894abb90/app/assets/javascripts/angular/missionhubApp.config.js#L22).
+By default running this repo locally hits the stage API server. If you need to test against the local API, you can edit [campusContactsApp.config.js](https://github.com/CruGlobal/campus-contacts-web/blob/master/app/assets/javascripts/angular/campusContactsApp.config.js#L17).
 
 ### Deployment
 

--- a/app/app.component.js
+++ b/app/app.component.js
@@ -2,7 +2,7 @@ import template from './app.html';
 import './components/navigation/navHeader.component';
 import './app.scss';
 
-angular.module('missionhubApp').component('app', {
+angular.module('campusContactsApp').component('app', {
     controller: appController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/all-tests.spec.js
+++ b/app/assets/javascripts/angular/all-tests.spec.js
@@ -2,7 +2,7 @@ import './main.js';
 import angular from 'angular';
 import 'angular-mocks';
 
-beforeEach(angular.mock.module('missionhubApp'));
+beforeEach(angular.mock.module('campusContactsApp'));
 
 beforeEach(
     angular.mock.module({

--- a/app/assets/javascripts/angular/campusContactsApp.config.js
+++ b/app/assets/javascripts/angular/campusContactsApp.config.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .config((envServiceProvider) => {
         envServiceProvider.config({
             domains: {

--- a/app/assets/javascripts/angular/campusContactsApp.config.js
+++ b/app/assets/javascripts/angular/campusContactsApp.config.js
@@ -3,26 +3,9 @@ angular
     .config((envServiceProvider) => {
         envServiceProvider.config({
             domains: {
-                development: ['localhost', 'missionhub.local'],
-                production: [
-                    'missionhub.com',
-                    'www.missionhub.com',
-                    'mhub.cc',
-                    'www.mhub.cc',
-                ],
-                productionCampusContacts: [
-                    'campuscontacts.cru.org',
-                    'ccontacts.app',
-                ],
+                development: ['localhost'],
+                production: ['campuscontacts.cru.org', 'ccontacts.app'],
                 staging: [
-                    'stage.missionhub.com',
-                    'stage.mhub.cc',
-                    'new.missionhub.com',
-                    '*.netlify.com',
-                    '*.netlify.app',
-                    '*.d11caubtn1mk5o.amplifyapp.com',
-                ],
-                stagingCampusContacts: [
                     // These wildcards need to be the last domains so they don't override matches above
                     '*.campuscontacts.cru.org',
                     '*.ccontacts.app',
@@ -32,40 +15,25 @@ angular
             vars: {
                 development: {
                     apiUrl: 'https://campus-contacts-api-stage.cru.org/apis/v4',
+                    publicUri: 'https://localhost:8080',
                     theKeyClientId: '4921314596573158029',
                     facebookAppId: '264148437992398',
                     surveyLinkPrefix: 'http://localhost:8080/s/',
-                    getMissionHub: 'http://localhost:8080',
                 },
                 staging: {
-                    apiUrl: 'https://api-stage.missionhub.com/apis/v4',
-                    theKeyClientId: '8138475243408077361',
-                    facebookAppId: '233292170040365',
-                    surveyLinkPrefix: 'https://stage.mhub.cc/s/',
-                    getMissionHub: 'https://stage.missionhub.com',
-                },
-                stagingCampusContacts: {
                     apiUrl: 'https://campus-contacts-api-stage.cru.org/apis/v4',
+                    publicUri: 'https://stage.campuscontacts.cru.org',
                     theKeyClientId: '9072391337803602723',
                     facebookAppId: '264148437992398',
                     surveyLinkPrefix: 'https://stage.ccontacts.app/s/',
-                    getMissionHub: 'https://stage.campuscontacts.cru.org',
                 },
                 production: {
-                    apiUrl: 'https://api.missionhub.com/apis/v4',
-                    theKeyClientId: '8480288430352167964',
-                    facebookAppId: '233292170040365',
-                    surveyLinkPrefix: 'https://mhub.cc/s/',
-                    googleAnalytics: 'UA-325725-21',
-                    getMissionHub: 'https://get.missionhub.com',
-                },
-                productionCampusContacts: {
                     apiUrl: 'https://campus-contacts-api.cru.org/apis/v4',
+                    publicUri: 'https://campuscontacts.cru.org',
                     theKeyClientId: '8575389827001069797',
                     facebookAppId: '264148437992398',
                     surveyLinkPrefix: 'https://ccontacts.app/s/',
                     googleAnalytics: 'UA-325725-21',
-                    getMissionHub: 'https://campuscontacts.cru.org',
                 },
                 defaults: {
                     theKeyUrl: 'https://thekey.me/cas',

--- a/app/assets/javascripts/angular/campusContactsApp.constants.js
+++ b/app/assets/javascripts/angular/campusContactsApp.constants.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import moment from 'moment';
 
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .constant('_', _)
     .constant('moment', moment)
     .constant('p2cOrgId', '8411')

--- a/app/assets/javascripts/angular/campusContactsApp.module.js
+++ b/app/assets/javascripts/angular/campusContactsApp.module.js
@@ -19,7 +19,7 @@ import 'angularjs-toaster/toaster.scss';
 import 'moment';
 import 'angular-smart-table';
 
-export default angular.module('missionhubApp', [
+export default angular.module('campusContactsApp', [
     ngAnimate,
     ngMdIcons,
     'beauby.jsonApiDataStore',

--- a/app/assets/javascripts/angular/campusContactsApp.routes.js
+++ b/app/assets/javascripts/angular/campusContactsApp.routes.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .config(function (
         $stateProvider,
         $locationProvider,

--- a/app/assets/javascripts/angular/campusContactsApp.run.js
+++ b/app/assets/javascripts/angular/campusContactsApp.run.js
@@ -30,21 +30,12 @@ angular
 
         analyticsService.init();
 
-        (envService.is('production') ||
-            envService.is('productionCampusContacts')) &&
-            $location.absUrl().match(/(www\.)?missionhub\.com\/?$/) &&
-            !authenticationService.isTokenValid() &&
-            ($window.location.href = envService.read('getMissionHub'));
-
         $transitions.onBefore({}, (transition) => {
             if (transition.to().data && transition.to().data.isPublic)
                 return true;
 
-            if (
-                $location.host().includes('mhub.cc') ||
-                $location.host().includes('ccontacts.app')
-            ) {
-                $window.location.href = envService.read('getMissionHub');
+            if ($location.host().includes('ccontacts.app')) {
+                $window.location.href = envService.read('publicUri');
                 return false;
             }
 

--- a/app/assets/javascripts/angular/campusContactsApp.run.js
+++ b/app/assets/javascripts/angular/campusContactsApp.run.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .run(function (
         $window,
         $rootScope,

--- a/app/assets/javascripts/angular/components/aboutModal/aboutModal.component.js
+++ b/app/assets/javascripts/angular/components/aboutModal/aboutModal.component.js
@@ -2,7 +2,7 @@ import template from './aboutModal.html';
 import './aboutModal.scss';
 
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .component('aboutModal', {
         controller: aboutModalController,
         template: template,

--- a/app/assets/javascripts/angular/components/accordion/accordion.component.js
+++ b/app/assets/javascripts/angular/components/accordion/accordion.component.js
@@ -1,7 +1,7 @@
 import template from './accordion.html';
 import './accordion.scss';
 
-angular.module('missionhubApp').component('accordion', {
+angular.module('campusContactsApp').component('accordion', {
     controller: accordionController,
     bindings: {
         collapsed: '=?',

--- a/app/assets/javascripts/angular/components/accordionToggle/accordionToggle.component.js
+++ b/app/assets/javascripts/angular/components/accordionToggle/accordionToggle.component.js
@@ -1,7 +1,7 @@
 import template from './accordionToggle.html';
 import './accordionToggle.scss';
 
-angular.module('missionhubApp').component('accordionToggle', {
+angular.module('campusContactsApp').component('accordionToggle', {
     controller: accordionToggleController,
     require: {
         accordion: '^',

--- a/app/assets/javascripts/angular/components/answerSheet/answerSheet.component.js
+++ b/app/assets/javascripts/angular/components/answerSheet/answerSheet.component.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 import template from './answerSheet.html';
 import './answerSheet.scss';
 
-angular.module('missionhubApp').component('answerSheet', {
+angular.module('campusContactsApp').component('answerSheet', {
     template: template,
     bindings: {
         answerSheet: '<',

--- a/app/assets/javascripts/angular/components/answerSheet/editAnswerSheetModal.component.js
+++ b/app/assets/javascripts/angular/components/answerSheet/editAnswerSheetModal.component.js
@@ -2,7 +2,7 @@ import template from './editAnswerSheetModal.html';
 
 import './editAnswerSheetModal.scss';
 
-angular.module('missionhubApp').component('editAnswerSheetModal', {
+angular.module('campusContactsApp').component('editAnswerSheetModal', {
     bindings: {
         resolve: '<',
         dismiss: '&',

--- a/app/assets/javascripts/angular/components/assignedLabelSelect/assignedLabelSelect.component.js
+++ b/app/assets/javascripts/angular/components/assignedLabelSelect/assignedLabelSelect.component.js
@@ -1,7 +1,7 @@
 import template from './assignedLabelSelect.html';
 import './assignedLabelSelect.scss';
 
-angular.module('missionhubApp').component('assignedLabelSelect', {
+angular.module('campusContactsApp').component('assignedLabelSelect', {
     bindings: {
         assigned: '=',
         organizationId: '<',

--- a/app/assets/javascripts/angular/components/assignedLabelSelect/assignedLabelSelect.service.js
+++ b/app/assets/javascripts/angular/components/assignedLabelSelect/assignedLabelSelect.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('assignedLabelSelectService', assignedLabelSelectService);
 
 function assignedLabelSelectService(httpProxy) {

--- a/app/assets/javascripts/angular/components/assignedPeopleSelect/assignedPeopleSelect.component.js
+++ b/app/assets/javascripts/angular/components/assignedPeopleSelect/assignedPeopleSelect.component.js
@@ -1,7 +1,7 @@
 import template from './assignedPeopleSelect.html';
 import './assignedPeopleSelect.scss';
 
-angular.module('missionhubApp').component('assignedPeopleSelect', {
+angular.module('campusContactsApp').component('assignedPeopleSelect', {
     bindings: {
         assigned: '=',
         ruleCode: '<',

--- a/app/assets/javascripts/angular/components/assignedPeopleSelect/assignedPeopleSelect.service.js
+++ b/app/assets/javascripts/angular/components/assignedPeopleSelect/assignedPeopleSelect.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('assignedPeopleSelectService', assignedPeopleSelectService);
 
 function assignedPeopleSelectService(

--- a/app/assets/javascripts/angular/components/asyncContent/asyncContent.component.js
+++ b/app/assets/javascripts/angular/components/asyncContent/asyncContent.component.js
@@ -1,7 +1,7 @@
 import template from './asyncContent.html';
 import './asyncContent.scss';
 
-angular.module('missionhubApp').component('asyncContent', {
+angular.module('campusContactsApp').component('asyncContent', {
     bindings: {
         ready: '<',
     },

--- a/app/assets/javascripts/angular/components/contactActions/contactActions.component.js
+++ b/app/assets/javascripts/angular/components/contactActions/contactActions.component.js
@@ -1,7 +1,7 @@
 import template from './contactActions.html';
 import './contactActions.scss';
 
-angular.module('missionhubApp').component('contactActions', {
+angular.module('campusContactsApp').component('contactActions', {
     bindings: {
         phone: '<',
         email: '<',

--- a/app/assets/javascripts/angular/components/copySurvey/copySurvey.component.js
+++ b/app/assets/javascripts/angular/components/copySurvey/copySurvey.component.js
@@ -1,6 +1,6 @@
 import template from './copySurvey.html';
 
-angular.module('missionhubApp').component('copySurvey', {
+angular.module('campusContactsApp').component('copySurvey', {
     controller: copySurveyController,
     bindings: {
         resolve: '<',

--- a/app/assets/javascripts/angular/components/createSurvey/createSurvey.component.js
+++ b/app/assets/javascripts/angular/components/createSurvey/createSurvey.component.js
@@ -1,6 +1,6 @@
 import template from './createSurvey.html';
 
-angular.module('missionhubApp').component('createSurvey', {
+angular.module('campusContactsApp').component('createSurvey', {
     controller: createSurveyController,
     bindings: {
         resolve: '<',

--- a/app/assets/javascripts/angular/components/dashboard/dashboard.component.js
+++ b/app/assets/javascripts/angular/components/dashboard/dashboard.component.js
@@ -1,6 +1,6 @@
 import template from './dashboard.html';
 
-angular.module('missionhubApp').component('dashboard', {
+angular.module('campusContactsApp').component('dashboard', {
     controller: DashboardController,
     template: template,
 });

--- a/app/assets/javascripts/angular/components/dashboard/subnav/dashboard-subnav.component.js
+++ b/app/assets/javascripts/angular/components/dashboard/subnav/dashboard-subnav.component.js
@@ -1,7 +1,7 @@
 import './dashboard-subnav.scss';
 import template from './dashboard-subnav.html';
 
-angular.module('missionhubApp').component('dashboardSubnav', {
+angular.module('campusContactsApp').component('dashboardSubnav', {
     controller: DashboardSubnavController,
     template: template,
 });

--- a/app/assets/javascripts/angular/components/editAddress/editAddress.component.js
+++ b/app/assets/javascripts/angular/components/editAddress/editAddress.component.js
@@ -1,7 +1,7 @@
 import template from './editAddress.html';
 import './editAddress.scss';
 
-angular.module('missionhubApp').component('editAddress', {
+angular.module('campusContactsApp').component('editAddress', {
     controller: editAddressController,
     bindings: {
         resolve: '<',

--- a/app/assets/javascripts/angular/components/editAddress/editAddress.service.js
+++ b/app/assets/javascripts/angular/components/editAddress/editAddress.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('editAddressService', editAddressService);
 
 function editAddressService(geoDataService, JsonApiDataStore, _) {

--- a/app/assets/javascripts/angular/components/editGroup/editGroup.component.js
+++ b/app/assets/javascripts/angular/components/editGroup/editGroup.component.js
@@ -1,7 +1,7 @@
 import template from './editGroup.html';
 import './editGroup.scss';
 
-angular.module('missionhubApp').component('editGroup', {
+angular.module('campusContactsApp').component('editGroup', {
     controller: editGroupController,
     bindings: {
         resolve: '<',

--- a/app/assets/javascripts/angular/components/editGroup/editGroup.service.js
+++ b/app/assets/javascripts/angular/components/editGroup/editGroup.service.js
@@ -1,4 +1,6 @@
-angular.module('missionhubApp').factory('editGroupService', editGroupService);
+angular
+    .module('campusContactsApp')
+    .factory('editGroupService', editGroupService);
 
 function editGroupService() {
     return {

--- a/app/assets/javascripts/angular/components/editGroupOrLabelAssignments/editGroupOrLabelAssignments.component.js
+++ b/app/assets/javascripts/angular/components/editGroupOrLabelAssignments/editGroupOrLabelAssignments.component.js
@@ -1,7 +1,7 @@
 import template from './editGroupOrLabelAssignments.html';
 import './editGroupOrLabelAssignments.scss';
 
-angular.module('missionhubApp').component('editGroupOrLabelAssignments', {
+angular.module('campusContactsApp').component('editGroupOrLabelAssignments', {
     controller: editGroupOrLabelAssignmentsController,
     bindings: {
         resolve: '<',

--- a/app/assets/javascripts/angular/components/editGroupOrLabelAssignments/editGroupOrLabelAssignments.service.js
+++ b/app/assets/javascripts/angular/components/editGroupOrLabelAssignments/editGroupOrLabelAssignments.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory(
         'editGroupOrLabelAssignmentsService',
         editGroupOrLabelAssignmentsService,

--- a/app/assets/javascripts/angular/components/editLabel/editLabel.component.js
+++ b/app/assets/javascripts/angular/components/editLabel/editLabel.component.js
@@ -1,6 +1,6 @@
 import template from './editLabel.html';
 
-angular.module('missionhubApp').component('editLabel', {
+angular.module('campusContactsApp').component('editLabel', {
     controller: editLabelController,
     bindings: {
         resolve: '<',

--- a/app/assets/javascripts/angular/components/groupMembersModal/groupMembersModal.component.js
+++ b/app/assets/javascripts/angular/components/groupMembersModal/groupMembersModal.component.js
@@ -1,7 +1,7 @@
 import template from './groupMembersModal.html';
 import './groupMembersModal.scss';
 
-angular.module('missionhubApp').component('groupMembersModal', {
+angular.module('campusContactsApp').component('groupMembersModal', {
     bindings: {
         resolve: '<',
         close: '&',

--- a/app/assets/javascripts/angular/components/groupMembersModal/groupMembersModal.service.js
+++ b/app/assets/javascripts/angular/components/groupMembersModal/groupMembersModal.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('groupMembersModalService', groupMembersModalService);
 
 function groupMembersModalService(

--- a/app/assets/javascripts/angular/components/iconButton/iconButton.component.js
+++ b/app/assets/javascripts/angular/components/iconButton/iconButton.component.js
@@ -7,7 +7,7 @@ import './iconButton.scss';
  * action is an ng-click handler, an href link, a ui-sref link, or some other click-based action.
  */
 
-angular.module('missionhubApp').component('iconButton', {
+angular.module('campusContactsApp').component('iconButton', {
     controller: iconButtonController,
     bindings: {
         disabled: '<',

--- a/app/assets/javascripts/angular/components/iconModal/iconModal.component.js
+++ b/app/assets/javascripts/angular/components/iconModal/iconModal.component.js
@@ -1,7 +1,7 @@
 import template from './iconModal.html';
 import './iconModal.scss';
 
-angular.module('missionhubApp').component('iconModal', {
+angular.module('campusContactsApp').component('iconModal', {
     template: template,
     bindings: {
         resolve: '<',

--- a/app/assets/javascripts/angular/components/interaction/interaction.component.js
+++ b/app/assets/javascripts/angular/components/interaction/interaction.component.js
@@ -3,7 +3,7 @@ import moment from 'moment';
 import template from './interaction.html';
 import './interaction.scss';
 
-angular.module('missionhubApp').component('interaction', {
+angular.module('campusContactsApp').component('interaction', {
     controller: interactionController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/loadingSpinner/loadingSpinner.component.js
+++ b/app/assets/javascripts/angular/components/loadingSpinner/loadingSpinner.component.js
@@ -1,7 +1,7 @@
 import template from './loadingSpinner.html';
 import './loadingSpinner.scss';
 
-angular.module('missionhubApp').component('loadingSpinner', {
+angular.module('campusContactsApp').component('loadingSpinner', {
     bindings: {
         size: '<',
     },

--- a/app/assets/javascripts/angular/components/massEdit/massEdit.component.js
+++ b/app/assets/javascripts/angular/components/massEdit/massEdit.component.js
@@ -1,7 +1,7 @@
 import template from './massEdit.html';
 import './massEdit.scss';
 
-angular.module('missionhubApp').component('massEdit', {
+angular.module('campusContactsApp').component('massEdit', {
     controller: massEditController,
     bindings: {
         resolve: '<',

--- a/app/assets/javascripts/angular/components/massEdit/massEdit.service.js
+++ b/app/assets/javascripts/angular/components/massEdit/massEdit.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('massEditService', massEditService);
+angular.module('campusContactsApp').factory('massEditService', massEditService);
 
 function massEditService(
     $q,

--- a/app/assets/javascripts/angular/components/messageModal/messageModal.component.js
+++ b/app/assets/javascripts/angular/components/messageModal/messageModal.component.js
@@ -3,7 +3,7 @@ import i18next from 'i18next';
 
 import template from './messageModal.html';
 
-angular.module('missionhubApp').component('messageModal', {
+angular.module('campusContactsApp').component('messageModal', {
     controller: messageModalController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/messageModal/messageModal.service.js
+++ b/app/assets/javascripts/angular/components/messageModal/messageModal.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('messageModalService', messageModalService);
 
 function messageModalService(httpProxy, personSelectionService) {

--- a/app/assets/javascripts/angular/components/ministryViewGroup/ministryViewGroup.component.js
+++ b/app/assets/javascripts/angular/components/ministryViewGroup/ministryViewGroup.component.js
@@ -1,7 +1,7 @@
 import template from './ministryViewGroup.html';
 import './ministryViewGroup.scss';
 
-angular.module('missionhubApp').component('ministryViewGroup', {
+angular.module('campusContactsApp').component('ministryViewGroup', {
     controller: ministryViewGroupController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/ministryViewGroup/ministryViewGroup.service.js
+++ b/app/assets/javascripts/angular/components/ministryViewGroup/ministryViewGroup.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('ministryViewGroupService', ministryViewGroupService);
 
 function ministryViewGroupService(groupsService, tFilter, moment, _) {

--- a/app/assets/javascripts/angular/components/ministryViewLabel/ministryViewLabel.component.js
+++ b/app/assets/javascripts/angular/components/ministryViewLabel/ministryViewLabel.component.js
@@ -1,7 +1,7 @@
 import template from './ministryViewLabel.html';
 import './ministryViewLabel.scss';
 
-angular.module('missionhubApp').component('ministryViewLabel', {
+angular.module('campusContactsApp').component('ministryViewLabel', {
     controller: ministryViewLabelController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/ministryViewPerson/ministryViewPerson.component.js
+++ b/app/assets/javascripts/angular/components/ministryViewPerson/ministryViewPerson.component.js
@@ -1,7 +1,7 @@
 import template from './ministryViewPerson.html';
 import './ministryViewPerson.scss';
 
-angular.module('missionhubApp').component('ministryViewPerson', {
+angular.module('campusContactsApp').component('ministryViewPerson', {
     controller: ministryViewPersonController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/multiselectList/multiselectList.component.js
+++ b/app/assets/javascripts/angular/components/multiselectList/multiselectList.component.js
@@ -1,7 +1,7 @@
 import template from './multiselectList.html';
 import './multiselectList.scss';
 
-angular.module('missionhubApp').component('multiselectList', {
+angular.module('campusContactsApp').component('multiselectList', {
     controller: multiselectListController,
     bindings: {
         // list of objects that have an id and name

--- a/app/assets/javascripts/angular/components/multiselectList/multiselectList.service.js
+++ b/app/assets/javascripts/angular/components/multiselectList/multiselectList.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('multiselectListService', multiselectListService);
 
 function multiselectListService(_) {

--- a/app/assets/javascripts/angular/components/myOrganizationsDashboard/myOrganizationsDashboard.component.js
+++ b/app/assets/javascripts/angular/components/myOrganizationsDashboard/myOrganizationsDashboard.component.js
@@ -1,7 +1,7 @@
 import template from './myOrganizationsDashboard.html';
 import './myOrganizationsDashboard.scss';
 
-angular.module('missionhubApp').component('myOrganizationsDashboard', {
+angular.module('campusContactsApp').component('myOrganizationsDashboard', {
     template: template,
     controller: function ($state) {
         this.$state = $state;

--- a/app/assets/javascripts/angular/components/myOrganizationsDashboard/myOrganizationsDashboard.service.js
+++ b/app/assets/javascripts/angular/components/myOrganizationsDashboard/myOrganizationsDashboard.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory(
         'myOrganizationsDashboardService',
         myOrganizationsDashboardService,

--- a/app/assets/javascripts/angular/components/myOrganizationsDashboardList/myOrganizationsDashboardList.component.js
+++ b/app/assets/javascripts/angular/components/myOrganizationsDashboardList/myOrganizationsDashboardList.component.js
@@ -1,6 +1,6 @@
 import template from './myOrganizationsDashboardList.html';
 
-angular.module('missionhubApp').component('myOrganizationsDashboardList', {
+angular.module('campusContactsApp').component('myOrganizationsDashboardList', {
     template: template,
     bindings: {
         rootOrgs: '<',

--- a/app/assets/javascripts/angular/components/myPeopleDashboard/myPeopleDashboard.component.js
+++ b/app/assets/javascripts/angular/components/myPeopleDashboard/myPeopleDashboard.component.js
@@ -7,7 +7,7 @@ import iosShare from '../../../../images/icons/ios-share.svg';
 import template from './myPeopleDashboard.html';
 import './myPeopleDashboard.scss';
 
-angular.module('missionhubApp').component('myPeopleDashboard', {
+angular.module('campusContactsApp').component('myPeopleDashboard', {
     controller: myPeopleDashboardController,
     bindings: {
         editMode: '<',

--- a/app/assets/javascripts/angular/components/myPeopleDashboard/myPeopleDashboard.service.js
+++ b/app/assets/javascripts/angular/components/myPeopleDashboard/myPeopleDashboard.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('myPeopleDashboardService', myPeopleDashboardService);
 
 function myPeopleDashboardService(httpProxy, modelsService, _) {

--- a/app/assets/javascripts/angular/components/orgManagement/orgManagement.component.js
+++ b/app/assets/javascripts/angular/components/orgManagement/orgManagement.component.js
@@ -1,7 +1,7 @@
 import template from './orgManagement.html';
 import './orgManagement.scss';
 
-angular.module('missionhubApp').component('orgManagement', {
+angular.module('campusContactsApp').component('orgManagement', {
     controller: orgManagementController,
     require: {
         organizationOverview: '^',

--- a/app/assets/javascripts/angular/components/orgManagement/orgManagementEdit.component.js
+++ b/app/assets/javascripts/angular/components/orgManagement/orgManagementEdit.component.js
@@ -2,7 +2,7 @@ import helpIcon from '../../../../images/icons/icon-help.svg';
 
 import template from './orgManagementEdit.html';
 
-angular.module('missionhubApp').component('orgManagementEdit', {
+angular.module('campusContactsApp').component('orgManagementEdit', {
     controller: orgManagementEditController,
     bindings: {
         org: '<',

--- a/app/assets/javascripts/angular/components/orgManagement/orgManagementSubOrg.component.js
+++ b/app/assets/javascripts/angular/components/orgManagement/orgManagementSubOrg.component.js
@@ -7,7 +7,7 @@ import warningIcon from '../../../../images/icons/icon-warning-2.svg';
 
 import template from './orgManagementSubOrg.html';
 
-angular.module('missionhubApp').component('orgManagementSubOrg', {
+angular.module('campusContactsApp').component('orgManagementSubOrg', {
     controller: orgManagementSubOrgController,
     bindings: {
         org: '<',

--- a/app/assets/javascripts/angular/components/organization/organization.component.js
+++ b/app/assets/javascripts/angular/components/organization/organization.component.js
@@ -1,7 +1,7 @@
 import template from './organization.html';
 import './organization.scss';
 
-angular.module('missionhubApp').component('organization', {
+angular.module('campusContactsApp').component('organization', {
     controller: organizationController,
     bindings: {
         options: '<?',

--- a/app/assets/javascripts/angular/components/organizationBreadcrumbs/organizationBreadcrumbs.component.js
+++ b/app/assets/javascripts/angular/components/organizationBreadcrumbs/organizationBreadcrumbs.component.js
@@ -1,7 +1,7 @@
 import template from './organizationBreadcrumbs.html';
 import './organizationBreadcrumbs.scss';
 
-angular.module('missionhubApp').component('organizationBreadcrumbs', {
+angular.module('campusContactsApp').component('organizationBreadcrumbs', {
     controller: organizationBreadcrumbsController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/organizationCleanup/organizationCleanup.component.js
+++ b/app/assets/javascripts/angular/components/organizationCleanup/organizationCleanup.component.js
@@ -5,7 +5,7 @@ import checkIcon from '../../../../images/icons/icon-check.svg';
 
 import template from './organizationCleanup.html';
 
-angular.module('missionhubApp').component('organizationCleanup', {
+angular.module('campusContactsApp').component('organizationCleanup', {
     bindings: {
         orgId: '<',
     },

--- a/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImport.component.js
+++ b/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImport.component.js
@@ -2,7 +2,7 @@ import template from './organizationContactImport.html';
 import './organizationContactImport.scss';
 import '../surveyOverview/surveyOverview.scss';
 
-angular.module('missionhubApp').component('organizationContactImport', {
+angular.module('campusContactsApp').component('organizationContactImport', {
     require: {
         organizationOverview: '^',
     },

--- a/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImportStep1.component.js
+++ b/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImportStep1.component.js
@@ -6,18 +6,20 @@ import errorIcon from '../../../../images/icons/icon-error.svg';
 
 import template from './organizationContactImportStep1.html';
 
-angular.module('missionhubApp').component('organizationContactImportStep1', {
-    bindings: {
-        org: '<',
-        surveys: '<',
-        next: '&',
-        selectedSurvey: '<',
-        fileName: '<',
-        csvData: '<',
-    },
-    template: template,
-    controller: organizationContactImportStep1Controller,
-});
+angular
+    .module('campusContactsApp')
+    .component('organizationContactImportStep1', {
+        bindings: {
+            org: '<',
+            surveys: '<',
+            next: '&',
+            selectedSurvey: '<',
+            fileName: '<',
+            csvData: '<',
+        },
+        template: template,
+        controller: organizationContactImportStep1Controller,
+    });
 
 function organizationContactImportStep1Controller($scope, $uibModal, $state) {
     this.fileIcon = fileIcon;

--- a/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImportStep2.component.js
+++ b/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImportStep2.component.js
@@ -3,17 +3,19 @@ import _ from 'lodash';
 
 import template from './organizationContactImportStep2.html';
 
-angular.module('missionhubApp').component('organizationContactImportStep2', {
-    bindings: {
-        next: '&',
-        previous: '&',
-        csvData: '<',
-        selectedSurvey: '<',
-        columnMap: '<',
-    },
-    template: template,
-    controller: organizationContactImportStep2Controller,
-});
+angular
+    .module('campusContactsApp')
+    .component('organizationContactImportStep2', {
+        bindings: {
+            next: '&',
+            previous: '&',
+            csvData: '<',
+            selectedSurvey: '<',
+            columnMap: '<',
+        },
+        template: template,
+        controller: organizationContactImportStep2Controller,
+    });
 
 function organizationContactImportStep2Controller($scope, surveyService) {
     this.currentPreviewRow = 1;

--- a/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImportStep3.component.js
+++ b/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImportStep3.component.js
@@ -4,18 +4,20 @@ import uuidv1 from 'uuid';
 
 import template from './organizationContactImportStep3.html';
 
-angular.module('missionhubApp').component('organizationContactImportStep3', {
-    bindings: {
-        org: '<',
-        next: '&',
-        previous: '&',
-        csvData: '<',
-        selectedSurvey: '<',
-        columnMap: '<',
-    },
-    template: template,
-    controller: organizationContactImportStep3Controller,
-});
+angular
+    .module('campusContactsApp')
+    .component('organizationContactImportStep3', {
+        bindings: {
+            org: '<',
+            next: '&',
+            previous: '&',
+            csvData: '<',
+            selectedSurvey: '<',
+            columnMap: '<',
+        },
+        template: template,
+        controller: organizationContactImportStep3Controller,
+    });
 
 function organizationContactImportStep3Controller(
     $scope,

--- a/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImportStep4.component.js
+++ b/app/assets/javascripts/angular/components/organizationContactImport/organizationContactImportStep4.component.js
@@ -2,13 +2,15 @@ import checkIcon from '../../../../images/icons/icon-check.svg';
 
 import template from './organizationContactImportStep4.html';
 
-angular.module('missionhubApp').component('organizationContactImportStep4', {
-    bindings: {
-        org: '<',
-    },
-    template: template,
-    controller: organizationContactImportStep4Controller,
-});
+angular
+    .module('campusContactsApp')
+    .component('organizationContactImportStep4', {
+        bindings: {
+            org: '<',
+        },
+        template: template,
+        controller: organizationContactImportStep4Controller,
+    });
 
 function organizationContactImportStep4Controller() {
     this.checkIcon = checkIcon;

--- a/app/assets/javascripts/angular/components/organizationOverview/organizationOverview.component.js
+++ b/app/assets/javascripts/angular/components/organizationOverview/organizationOverview.component.js
@@ -2,7 +2,7 @@ import './organizationOverview.scss';
 
 import template from './organizationOverview.html';
 
-angular.module('missionhubApp').component('organizationOverview', {
+angular.module('campusContactsApp').component('organizationOverview', {
     controller: organizationOverviewController,
     bindings: {
         org: '<',

--- a/app/assets/javascripts/angular/components/organizationOverview/organizationOverview.service.js
+++ b/app/assets/javascripts/angular/components/organizationOverview/organizationOverview.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('organizationOverviewService', organizationOverviewService);
 
 function organizationOverviewService(

--- a/app/assets/javascripts/angular/components/organizationOverviewGroups/organizationOverviewGroups.component.js
+++ b/app/assets/javascripts/angular/components/organizationOverviewGroups/organizationOverviewGroups.component.js
@@ -1,7 +1,7 @@
 import template from './organizationOverviewGroups.html';
 import './organizationOverviewGroups.scss';
 
-angular.module('missionhubApp').component('organizationOverviewGroups', {
+angular.module('campusContactsApp').component('organizationOverviewGroups', {
     controller: organizationOverviewGroupsController,
     require: {
         organizationOverview: '^',

--- a/app/assets/javascripts/angular/components/organizationOverviewLabels/organizationOverviewLabels.component.js
+++ b/app/assets/javascripts/angular/components/organizationOverviewLabels/organizationOverviewLabels.component.js
@@ -1,7 +1,7 @@
 import template from './organizationOverviewLabels.html';
 import './organizationOverviewLabels.scss';
 
-angular.module('missionhubApp').component('organizationOverviewLabels', {
+angular.module('campusContactsApp').component('organizationOverviewLabels', {
     controller: organizationOverviewLabelsController,
     require: {
         organizationOverview: '^',

--- a/app/assets/javascripts/angular/components/organizationOverviewPeople/organizationOverviewPeople.component.js
+++ b/app/assets/javascripts/angular/components/organizationOverviewPeople/organizationOverviewPeople.component.js
@@ -1,6 +1,6 @@
 import template from './organizationOverviewPeople.html';
 
-angular.module('missionhubApp').component('organizationOverviewPeople', {
+angular.module('campusContactsApp').component('organizationOverviewPeople', {
     controller: organizationOverviewPeopleController,
     require: {
         organizationOverview: '^',

--- a/app/assets/javascripts/angular/components/organizationOverviewSuborgs/organizationOverviewSuborgs.component.js
+++ b/app/assets/javascripts/angular/components/organizationOverviewSuborgs/organizationOverviewSuborgs.component.js
@@ -1,7 +1,7 @@
 import template from './organizationOverviewSuborgs.html';
 import './organizationOverviewSuborgs.scss';
 
-angular.module('missionhubApp').component('organizationOverviewSuborgs', {
+angular.module('campusContactsApp').component('organizationOverviewSuborgs', {
     controller: organizationOverviewSuborgsController,
     bindings: {
         $transition$: '<',

--- a/app/assets/javascripts/angular/components/organizationOverviewSuborgs/organizationOverviewSuborgs.service.js
+++ b/app/assets/javascripts/angular/components/organizationOverviewSuborgs/organizationOverviewSuborgs.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory(
         'organizationOverviewSuborgsService',
         organizationOverviewSuborgsService,

--- a/app/assets/javascripts/angular/components/organizationOverviewSurveyResponses/organizationOverviewSurveyResponses.component.js
+++ b/app/assets/javascripts/angular/components/organizationOverviewSurveyResponses/organizationOverviewSurveyResponses.component.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import template from './organizationOverviewSurveyResponses.html';
 
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .component('organizationOverviewSurveyResponses', {
         require: {
             organizationOverview: '^',

--- a/app/assets/javascripts/angular/components/organizationOverviewSurveys/organizationOverviewSurveys.component.js
+++ b/app/assets/javascripts/angular/components/organizationOverviewSurveys/organizationOverviewSurveys.component.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 
 import template from './organizationOverviewSurveys.html';
 
-angular.module('missionhubApp').component('organizationOverviewSurveys', {
+angular.module('campusContactsApp').component('organizationOverviewSurveys', {
     require: {
         organizationOverview: '^',
     },

--- a/app/assets/javascripts/angular/components/organizationOverviewTeam/organizationOverviewTeam.component.js
+++ b/app/assets/javascripts/angular/components/organizationOverviewTeam/organizationOverviewTeam.component.js
@@ -1,6 +1,6 @@
 import template from './organizationOverviewTeam.html';
 
-angular.module('missionhubApp').component('organizationOverviewTeam', {
+angular.module('campusContactsApp').component('organizationOverviewTeam', {
     controller: organizationOverviewTeamController,
     require: {
         organizationOverview: '^',

--- a/app/assets/javascripts/angular/components/organizationOverviewTeam/organizationOverviewTeam.service.js
+++ b/app/assets/javascripts/angular/components/organizationOverviewTeam/organizationOverviewTeam.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory(
         'organizationOverviewTeamService',
         organizationOverviewTeamService,

--- a/app/assets/javascripts/angular/components/organizationSignatures/organizationSignatures.component.js
+++ b/app/assets/javascripts/angular/components/organizationSignatures/organizationSignatures.component.js
@@ -1,7 +1,7 @@
 import template from './organizationSignatures.html';
 import './organizationSignatures.scss';
 
-angular.module('missionhubApp').component('organizationSignatures', {
+angular.module('campusContactsApp').component('organizationSignatures', {
     bindings: {
         orgId: '<',
     },

--- a/app/assets/javascripts/angular/components/organizationSignatures/organizationSignaturesSign.component.js
+++ b/app/assets/javascripts/angular/components/organizationSignatures/organizationSignaturesSign.component.js
@@ -1,6 +1,6 @@
 import template from './organizationSignaturesSign.html';
 
-angular.module('missionhubApp').component('organizationSignaturesSign', {
+angular.module('campusContactsApp').component('organizationSignaturesSign', {
     template: template,
     controller: organizationSignaturesSignController,
 });

--- a/app/assets/javascripts/angular/components/organizationalStats/organizationalStats.component.js
+++ b/app/assets/javascripts/angular/components/organizationalStats/organizationalStats.component.js
@@ -1,7 +1,7 @@
 import template from './organizationalStats.html';
 import './organizationalStats.scss';
 
-angular.module('missionhubApp').component('organizationalStats', {
+angular.module('campusContactsApp').component('organizationalStats', {
     bindings: {
         org: '<',
     },

--- a/app/assets/javascripts/angular/components/peopleFiltersPanel/peopleFiltersPanel.component.js
+++ b/app/assets/javascripts/angular/components/peopleFiltersPanel/peopleFiltersPanel.component.js
@@ -1,7 +1,7 @@
 import template from './peopleFiltersPanel.html';
 import './peopleFiltersPanel.scss';
 
-angular.module('missionhubApp').component('peopleFiltersPanel', {
+angular.module('campusContactsApp').component('peopleFiltersPanel', {
     controller: peopleFiltersPanelController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/peopleFiltersPanel/peopleFiltersPanel.service.js
+++ b/app/assets/javascripts/angular/components/peopleFiltersPanel/peopleFiltersPanel.service.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('peopleFiltersPanelService', peopleFiltersPanelService);
 
 function peopleFiltersPanelService() {

--- a/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.component.js
+++ b/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.component.js
@@ -13,7 +13,7 @@ import closeIcon from '../../../../images/icons/close.svg';
 
 import template from './peopleScreen.html';
 
-angular.module('missionhubApp').component('peopleScreen', {
+angular.module('campusContactsApp').component('peopleScreen', {
     controller: peopleScreenController,
     bindings: {
         org: '<',

--- a/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.service.js
+++ b/app/assets/javascripts/angular/components/peopleScreen/peopleScreen.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('peopleScreenService', peopleScreenService);
 
 function peopleScreenService(

--- a/app/assets/javascripts/angular/components/peopleViewPerson/peopleViewPerson.component.js
+++ b/app/assets/javascripts/angular/components/peopleViewPerson/peopleViewPerson.component.js
@@ -1,7 +1,7 @@
 import template from './peopleViewPerson.html';
 import './peopleViewPerson.scss';
 
-angular.module('missionhubApp').component('peopleViewPerson', {
+angular.module('campusContactsApp').component('peopleViewPerson', {
     controller: peopleViewPersonController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/personActivity/personActivity.component.js
+++ b/app/assets/javascripts/angular/components/personActivity/personActivity.component.js
@@ -1,7 +1,7 @@
 import template from './personActivity.html';
 import './personActivity.scss';
 
-angular.module('missionhubApp').component('personActivity', {
+angular.module('campusContactsApp').component('personActivity', {
     controller: personActivityController,
     require: {
         personTab: '^personPage',

--- a/app/assets/javascripts/angular/components/personAssigned/personAssigned.component.js
+++ b/app/assets/javascripts/angular/components/personAssigned/personAssigned.component.js
@@ -1,7 +1,7 @@
 import template from './personAssigned.html';
 import './personAssigned.scss';
 
-angular.module('missionhubApp').component('personAssigned', {
+angular.module('campusContactsApp').component('personAssigned', {
     controller: personAssignedController,
     require: {
         personTab: '^personPage',

--- a/app/assets/javascripts/angular/components/personAssigned/personAssigned.service.js
+++ b/app/assets/javascripts/angular/components/personAssigned/personAssigned.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('personAssignedService', personAssignedService);
 
 function personAssignedService(JsonApiDataStore, personService) {

--- a/app/assets/javascripts/angular/components/personHistory/personHistory.component.js
+++ b/app/assets/javascripts/angular/components/personHistory/personHistory.component.js
@@ -1,7 +1,7 @@
 import template from './personHistory.html';
 import './personHistory.scss';
 
-angular.module('missionhubApp').component('personHistory', {
+angular.module('campusContactsApp').component('personHistory', {
     controller: personHistoryController,
     bindings: {
         history: '<',

--- a/app/assets/javascripts/angular/components/personHistory/personHistory.service.js
+++ b/app/assets/javascripts/angular/components/personHistory/personHistory.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('personHistoryService', personHistoryService);
 
 function personHistoryService(_) {

--- a/app/assets/javascripts/angular/components/personMultiselect/personMultiselect.component.js
+++ b/app/assets/javascripts/angular/components/personMultiselect/personMultiselect.component.js
@@ -1,7 +1,7 @@
 import template from './personMultiselect.html';
 import './personMultiselect.scss';
 
-angular.module('missionhubApp').component('personMultiselect', {
+angular.module('campusContactsApp').component('personMultiselect', {
     controller: personMultiselectController,
     bindings: {
         organizationId: '<',

--- a/app/assets/javascripts/angular/components/personPage/personPage.component.js
+++ b/app/assets/javascripts/angular/components/personPage/personPage.component.js
@@ -3,7 +3,7 @@ import './personPage.scss';
 
 import template from './personPage.html';
 
-angular.module('missionhubApp').component('personPage', {
+angular.module('campusContactsApp').component('personPage', {
     controller: personPageController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/personPage/personPage.service.js
+++ b/app/assets/javascripts/angular/components/personPage/personPage.service.js
@@ -1,4 +1,6 @@
-angular.module('missionhubApp').factory('personPageService', personPageService);
+angular
+    .module('campusContactsApp')
+    .factory('personPageService', personPageService);
 
 function personPageService(httpProxy, modelsService, _) {
     return {

--- a/app/assets/javascripts/angular/components/personProfile/personProfile.component.js
+++ b/app/assets/javascripts/angular/components/personProfile/personProfile.component.js
@@ -1,7 +1,7 @@
 import template from './personProfile.html';
 import './personProfile.scss';
 
-angular.module('missionhubApp').component('personProfile', {
+angular.module('campusContactsApp').component('personProfile', {
     controller: personProfileController,
     require: {
         personTab: '^personPage',

--- a/app/assets/javascripts/angular/components/personProfile/personProfile.service.js
+++ b/app/assets/javascripts/angular/components/personProfile/personProfile.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('personProfileService', personProfileService);
 
 function personProfileService(

--- a/app/assets/javascripts/angular/components/preloadState/preloadState.component.js
+++ b/app/assets/javascripts/angular/components/preloadState/preloadState.component.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').component('preloadState', {
+angular.module('campusContactsApp').component('preloadState', {
     controller: preloadStateController,
     bindings: {
         name: '@',

--- a/app/assets/javascripts/angular/components/publicPhoneNumberValidation/publicPhoneNumberValidation.component.js
+++ b/app/assets/javascripts/angular/components/publicPhoneNumberValidation/publicPhoneNumberValidation.component.js
@@ -1,6 +1,6 @@
 import template from './publicPhoneNumberValidation.html';
 
-angular.module('missionhubApp').component('publicPhoneNumberValidation', {
+angular.module('campusContactsApp').component('publicPhoneNumberValidation', {
     bindings: {
         phoneNumberValidation: '<',
     },

--- a/app/assets/javascripts/angular/components/publicSurvey/publicSurvey.component.js
+++ b/app/assets/javascripts/angular/components/publicSurvey/publicSurvey.component.js
@@ -1,6 +1,6 @@
 import template from './publicSurvey.html';
 
-angular.module('missionhubApp').component('publicSurvey', {
+angular.module('campusContactsApp').component('publicSurvey', {
     bindings: {
         survey: '<',
         preview: '<',

--- a/app/assets/javascripts/angular/components/reportMovementIndicators/confirmMovementIndicators/confirmMovementIndicators.component.js
+++ b/app/assets/javascripts/angular/components/reportMovementIndicators/confirmMovementIndicators/confirmMovementIndicators.component.js
@@ -7,15 +7,17 @@ import checkIcon from '../../../../../images/icons/icon-check-stylized.svg';
 
 import template from './confirmMovementIndicators.html';
 
-angular.module('missionhubApp').component('reportMovementIndicatorsConfirm', {
-    controller: reportMovementIndicatorsConfirmController,
-    bindings: {
-        orgId: '<',
-        next: '&',
-        previous: '&',
-    },
-    template,
-});
+angular
+    .module('campusContactsApp')
+    .component('reportMovementIndicatorsConfirm', {
+        controller: reportMovementIndicatorsConfirmController,
+        bindings: {
+            orgId: '<',
+            next: '&',
+            previous: '&',
+        },
+        template,
+    });
 
 function reportMovementIndicatorsConfirmController(httpProxy, $uibModal) {
     this.fieldMap = {

--- a/app/assets/javascripts/angular/components/reportMovementIndicators/confirmMovementIndicators/tooltip/tooltip.component.js
+++ b/app/assets/javascripts/angular/components/reportMovementIndicators/confirmMovementIndicators/tooltip/tooltip.component.js
@@ -1,7 +1,7 @@
 import template from './tooltip.html';
 import './tooltip.scss';
 
-angular.module('missionhubApp').component('tooltip', {
+angular.module('campusContactsApp').component('tooltip', {
     bindings: {
         content: '@',
     },

--- a/app/assets/javascripts/angular/components/reportMovementIndicators/reportMovementIndicators.component.js
+++ b/app/assets/javascripts/angular/components/reportMovementIndicators/reportMovementIndicators.component.js
@@ -1,6 +1,6 @@
 import template from './reportMovementIndicators.html';
 
-angular.module('missionhubApp').component('reportMovementIndicators', {
+angular.module('campusContactsApp').component('reportMovementIndicators', {
     controller: reportMovementIndicatorsController,
     bindings: {
         orgId: '<',

--- a/app/assets/javascripts/angular/components/reportMovementIndicators/suggestedActions/accordion/suggestedActionsAccordion.component.js
+++ b/app/assets/javascripts/angular/components/reportMovementIndicators/suggestedActions/accordion/suggestedActionsAccordion.component.js
@@ -4,7 +4,7 @@ import template from './suggestedActionsAccordion.html';
 import './suggestedActionsAccordion.scss';
 
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .component('reportMovementIndicatorsSuggestedActionsAccordion', {
         controller: reportMovementIndicatorsSuggestedActionsController,
         bindings: {

--- a/app/assets/javascripts/angular/components/reportMovementIndicators/suggestedActions/suggestedActions.component.js
+++ b/app/assets/javascripts/angular/components/reportMovementIndicators/suggestedActions/suggestedActions.component.js
@@ -3,7 +3,7 @@ import i18next from 'i18next';
 import template from './suggestedActions.html';
 
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .component('reportMovementIndicatorsSuggestedActions', {
         controller: reportMovementIndicatorsSuggestedActionsController,
         bindings: {

--- a/app/assets/javascripts/angular/components/reportPeriod/reportPeriod.component.js
+++ b/app/assets/javascripts/angular/components/reportPeriod/reportPeriod.component.js
@@ -1,7 +1,7 @@
 import template from './reportPeriod.html';
 import './reportPeriod.scss';
 
-angular.module('missionhubApp').component('reportPeriod', {
+angular.module('campusContactsApp').component('reportPeriod', {
     controller: reportPeriodController,
     template: template,
 });

--- a/app/assets/javascripts/angular/components/statsHeader/statsHeader.component.js
+++ b/app/assets/javascripts/angular/components/statsHeader/statsHeader.component.js
@@ -1,7 +1,7 @@
 import template from './statsHeader.html';
 import './statsHeader.scss';
 
-angular.module('missionhubApp').component('statsHeader', {
+angular.module('campusContactsApp').component('statsHeader', {
     controller: statsHeaderController,
     template: template,
 });

--- a/app/assets/javascripts/angular/components/surveyOverview/surveyOverview.component.js
+++ b/app/assets/javascripts/angular/components/surveyOverview/surveyOverview.component.js
@@ -3,7 +3,7 @@ import chevronLeftIcon from '../../../../images/icons/chevronLeft.svg';
 
 import template from './surveyOverview.html';
 
-angular.module('missionhubApp').component('surveyOverview', {
+angular.module('campusContactsApp').component('surveyOverview', {
     controller: surveyOverviewController,
     bindings: {
         survey: '<',

--- a/app/assets/javascripts/angular/components/surveyOverviewKeywordTab/surveyOverviewKeyword.component.js
+++ b/app/assets/javascripts/angular/components/surveyOverviewKeywordTab/surveyOverviewKeyword.component.js
@@ -6,7 +6,7 @@ import clockIcon from '../../../../images/icon-clock.svg';
 
 import template from './surveyOverviewKeyword.html';
 
-angular.module('missionhubApp').component('surveyOverviewKeyword', {
+angular.module('campusContactsApp').component('surveyOverviewKeyword', {
     controller: surveyOverviewKeywordController,
     bindings: {
         survey: '<',

--- a/app/assets/javascripts/angular/components/surveyOverviewQuestionsTab/autoAssignLabelNotifyModal.component.js
+++ b/app/assets/javascripts/angular/components/surveyOverviewQuestionsTab/autoAssignLabelNotifyModal.component.js
@@ -1,7 +1,7 @@
 import template from './autoAssignLabelNotifyModal.html';
 import './autoAssignLabelNotifyModal.scss';
 
-angular.module('missionhubApp').component('autoAssignLabelNotifyModal', {
+angular.module('campusContactsApp').component('autoAssignLabelNotifyModal', {
     controller: autoAssignLabelNotifyModalController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/surveyOverviewQuestionsTab/predefinedQuestionsModal.component.js
+++ b/app/assets/javascripts/angular/components/surveyOverviewQuestionsTab/predefinedQuestionsModal.component.js
@@ -1,6 +1,6 @@
 import template from './predefinedQuestionsModal.html';
 
-angular.module('missionhubApp').component('predefinedQuestionsModal', {
+angular.module('campusContactsApp').component('predefinedQuestionsModal', {
     controller: predefinedQuestionsModalController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/surveyOverviewQuestionsTab/surveyOverviewQuestions.component.js
+++ b/app/assets/javascripts/angular/components/surveyOverviewQuestionsTab/surveyOverviewQuestions.component.js
@@ -11,7 +11,7 @@ import warningIcon from '../../../../images/icons/icon-warning-2.svg';
 
 import template from './surveyOverviewQuestions.html';
 
-angular.module('missionhubApp').component('surveyOverviewQuestions', {
+angular.module('campusContactsApp').component('surveyOverviewQuestions', {
     controller: surveyOverviewQuestionsController,
     bindings: {
         survey: '<',

--- a/app/assets/javascripts/angular/components/surveyOverviewSettingsTab/surveyOverviewSettings.component.js
+++ b/app/assets/javascripts/angular/components/surveyOverviewSettingsTab/surveyOverviewSettings.component.js
@@ -5,7 +5,7 @@ import helpIcon from '../../../../images/icon-help.svg';
 import template from './surveyOverviewSettings.html';
 import './surveyOverviewSettings.scss';
 
-angular.module('missionhubApp').component('surveyOverviewSettings', {
+angular.module('campusContactsApp').component('surveyOverviewSettings', {
     controller: surveyOverviewSettingsController,
     bindings: {
         survey: '<',

--- a/app/assets/javascripts/angular/components/surveyResponses/addSurveyResponseModal.component.js
+++ b/app/assets/javascripts/angular/components/surveyResponses/addSurveyResponseModal.component.js
@@ -2,7 +2,7 @@ import template from './addSurveyResponseModal.html';
 
 import './addSurveyResponseModal.scss';
 
-angular.module('missionhubApp').component('addSurveyResponseModal', {
+angular.module('campusContactsApp').component('addSurveyResponseModal', {
     bindings: {
         resolve: '<',
         dismiss: '&',

--- a/app/assets/javascripts/angular/components/surveyResponses/surveyResponses.component.js
+++ b/app/assets/javascripts/angular/components/surveyResponses/surveyResponses.component.js
@@ -3,7 +3,7 @@ import chevronLeftIcon from '../../../../images/icons/chevronLeft.svg';
 
 import template from './surveyResponses.html';
 
-angular.module('missionhubApp').component('surveyResponses', {
+angular.module('campusContactsApp').component('surveyResponses', {
     controller: surveyResponsesController,
     bindings: {
         survey: '<',

--- a/app/assets/javascripts/angular/components/surveyTypeformModal/surveyTypeformModal.component.js
+++ b/app/assets/javascripts/angular/components/surveyTypeformModal/surveyTypeformModal.component.js
@@ -20,7 +20,7 @@ function surveyTypeformModalController($document, $sce) {
     );
 
     vm.copy = () => {
-        const el = vm.$document[0].getElementById('missionhub-url');
+        const el = vm.$document[0].getElementById('campus-contacts-url');
         el.select();
         vm.$document[0].execCommand('copy');
         vm.copied = true;

--- a/app/assets/javascripts/angular/components/surveyTypeformModal/surveyTypeformModal.component.js
+++ b/app/assets/javascripts/angular/components/surveyTypeformModal/surveyTypeformModal.component.js
@@ -3,7 +3,7 @@ import i18next from 'i18next';
 import template from './surveyTypeformModal.html';
 import './surveyTypeformModal.scss';
 
-angular.module('missionhubApp').component('surveyTypeformModal', {
+angular.module('campusContactsApp').component('surveyTypeformModal', {
     controller: surveyTypeformModalController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/surveyTypeformModal/surveyTypeformModal.html
+++ b/app/assets/javascripts/angular/components/surveyTypeformModal/surveyTypeformModal.html
@@ -20,12 +20,12 @@
         <li>{{ 'ministries.surveys.typeform.step5' | t }}</li>
     </ol>
     <p>{{ 'ministries.surveys.typeform.conclusion' | t }}</p>
-    <label for="missionhub-url"
-        >{{ 'ministries.surveys.typeform.missionHubUrl' | t }}</label
+    <label for="campus-contacts-url"
+        >{{ 'ministries.surveys.typeform.campusContactsUrl' | t }}</label
     >
     <textarea
-        id="missionhub-url"
-        name="missionhub-url"
+        id="campus-contacts-url"
+        name="campus-contacts-url"
         class="form-control"
         ng-model="$ctrl.resolve.webhookUrl"
         readonly

--- a/app/assets/javascripts/angular/components/surveys/surveyForm.component.js
+++ b/app/assets/javascripts/angular/components/surveys/surveyForm.component.js
@@ -16,7 +16,7 @@ const bindings = {
 // Note: angularjs-annotate doesn't work if you try move the controller part of the component config to a shared object
 
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .component('surveyFormUser', {
         controller: surveyFormController,
         bindings,

--- a/app/assets/javascripts/angular/components/transferModal/transferModal.component.js
+++ b/app/assets/javascripts/angular/components/transferModal/transferModal.component.js
@@ -1,7 +1,7 @@
 import template from './transferModal.html';
 import './transferModal.scss';
 
-angular.module('missionhubApp').component('transferModal', {
+angular.module('campusContactsApp').component('transferModal', {
     controller: transferModalController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/transferModal/transferModal.service.js
+++ b/app/assets/javascripts/angular/components/transferModal/transferModal.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('transferService', transferService);
+angular.module('campusContactsApp').factory('transferService', transferService);
 
 function transferService(httpProxy, JsonApiDataStore, personSelectionService) {
     return {

--- a/app/assets/javascripts/angular/components/unsubscribe/unsubscribe.component.js
+++ b/app/assets/javascripts/angular/components/unsubscribe/unsubscribe.component.js
@@ -1,7 +1,7 @@
 import template from './unsubscribe.html';
 import './unsubscribe.scss';
 
-angular.module('missionhubApp').component('unsubscribe', {
+angular.module('campusContactsApp').component('unsubscribe', {
     controller: unsubscribeController,
     template: template,
     bindings: {

--- a/app/assets/javascripts/angular/components/user-preferences/user-preferences.component.js
+++ b/app/assets/javascripts/angular/components/user-preferences/user-preferences.component.js
@@ -43,7 +43,7 @@ class UserPreferences {
     }
 }
 
-angular.module('missionhubApp').component('userPreferences', {
+angular.module('campusContactsApp').component('userPreferences', {
     controller: UserPreferences,
     template: template,
 });

--- a/app/assets/javascripts/angular/decorators/templateRequest.js
+++ b/app/assets/javascripts/angular/decorators/templateRequest.js
@@ -1,7 +1,9 @@
 /*
  * Decorate $templateRequest so that failures can be retried.
  */
-angular.module('missionhubApp').decorator('$templateRequest', $templateRequest);
+angular
+    .module('campusContactsApp')
+    .decorator('$templateRequest', $templateRequest);
 
 function $templateRequest($delegate, errorService, tFilter, _) {
     var retryConfig = _.defaults(

--- a/app/assets/javascripts/angular/directives/autoGrow.directive.js
+++ b/app/assets/javascripts/angular/directives/autoGrow.directive.js
@@ -1,5 +1,5 @@
 // Copied from https://gist.github.com/thomseddon/4703968
-angular.module('missionhubApp').directive('autoGrow', function ($document) {
+angular.module('campusContactsApp').directive('autoGrow', function ($document) {
     function link(scope, element) {
         var minHeight = element[0].offsetHeight;
         var paddingLeft = element.css('paddingLeft');

--- a/app/assets/javascripts/angular/directives/exposeSelect.js
+++ b/app/assets/javascripts/angular/directives/exposeSelect.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').directive('exposeSelect', function () {
+angular.module('campusContactsApp').directive('exposeSelect', function () {
     return {
         controller: function ($scope) {
             // Put the $select instance from the ui-select component on the parent scope so that the parent of

--- a/app/assets/javascripts/angular/directives/focus.js
+++ b/app/assets/javascripts/angular/directives/focus.js
@@ -1,5 +1,5 @@
 // This directive focuses the element if the "focus" attribute is truthy.
-angular.module('missionhubApp').directive('focus', function () {
+angular.module('campusContactsApp').directive('focus', function () {
     return {
         restrict: 'A',
         scope: { focus: '<' },

--- a/app/assets/javascripts/angular/directives/onClickAway.directive.js
+++ b/app/assets/javascripts/angular/directives/onClickAway.directive.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .directive('onClickAway', function ($window, $parse, $timeout) {
         return {
             restrict: 'A',

--- a/app/assets/javascripts/angular/directives/safeSubmit.directive.js
+++ b/app/assets/javascripts/angular/directives/safeSubmit.directive.js
@@ -1,6 +1,6 @@
 // ng-safe-submit is similar to ng-submit except that it automatically prevents double-submissions. The
 // ng-safe-submit event handler can return a promise. If it does, the form is disabled until the promise resolves.
-angular.module('missionhubApp').directive('ngSafeSubmit', function ($q, _) {
+angular.module('campusContactsApp').directive('ngSafeSubmit', function ($q, _) {
     return {
         restrict: 'A',
         scope: { ngSafeSubmit: '&' },

--- a/app/assets/javascripts/angular/filters/mailto.filter.js
+++ b/app/assets/javascripts/angular/filters/mailto.filter.js
@@ -5,7 +5,7 @@
  * whereas the second form causes the href attribute to be set to the invalid link "mailto:" and styled as a link
  * even though it really is not.
  */
-angular.module('missionhubApp').filter('mailto', function () {
+angular.module('campusContactsApp').filter('mailto', function () {
     return function (address) {
         return address ? 'mailto:' + address : null;
     };

--- a/app/assets/javascripts/angular/filters/personName.filter.js
+++ b/app/assets/javascripts/angular/filters/personName.filter.js
@@ -1,7 +1,7 @@
 /*
  * The personName filter takes a person and converts it into the person's name.
  */
-angular.module('missionhubApp').filter('personName', function (_) {
+angular.module('campusContactsApp').filter('personName', function (_) {
     return function (person, type) {
         if (!person) {
             return null;

--- a/app/assets/javascripts/angular/filters/phone.filter.js
+++ b/app/assets/javascripts/angular/filters/phone.filter.js
@@ -1,6 +1,6 @@
 // Adapted from: http://stackoverflow.com/questions/12700145/how-to-format-a-telephone-number-in-angularjs
 
-angular.module('missionhubApp').filter('phone', function () {
+angular.module('campusContactsApp').filter('phone', function () {
     return function (inputNumber) {
         if (!inputNumber) {
             return '';

--- a/app/assets/javascripts/angular/filters/translation.filter.js
+++ b/app/assets/javascripts/angular/filters/translation.filter.js
@@ -1,6 +1,6 @@
 import i18next from 'i18next';
 
-angular.module('missionhubApp').filter('t', function () {
+angular.module('campusContactsApp').filter('t', function () {
     function translateFilter(key, options) {
         return i18next.t(key, options);
     }

--- a/app/assets/javascripts/angular/main.js
+++ b/app/assets/javascripts/angular/main.js
@@ -2,12 +2,12 @@ import './workboxServiceWorker';
 
 import '../../../../src/i18n/i18next.config';
 
-import './missionhubApp.module';
-import './missionhubApp.constants';
-import './missionhubApp.config';
+import './campusContactsApp.module';
+import './campusContactsApp.constants';
+import './campusContactsApp.config';
 import './rollbar.config';
-import './missionhubApp.routes';
-import './missionhubApp.run';
+import './campusContactsApp.routes';
+import './campusContactsApp.run';
 
 import '../../../app.component';
 import '../../../components/authentication/signIn.component';

--- a/app/assets/javascripts/angular/rollbar.config.js
+++ b/app/assets/javascripts/angular/rollbar.config.js
@@ -2,7 +2,7 @@ import rollbar from 'rollbar';
 import StackTrace from 'stacktrace-js';
 
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .config(function (rollbarAccessToken, envServiceProvider, $provide, _) {
         var rollbarConfig = {
             accessToken: rollbarAccessToken,

--- a/app/assets/javascripts/angular/services/analyticsService.js
+++ b/app/assets/javascripts/angular/services/analyticsService.js
@@ -13,7 +13,6 @@ function analyticsService(
         if (!angular.isFunction($window.ga)) return;
 
         $window.ga('create', envService.read('googleAnalytics'), 'auto', {
-            legacyCookieDomain: 'missionhub.com',
             allowLinker: true,
             sampleRate: 100,
         });

--- a/app/assets/javascripts/angular/services/analyticsService.js
+++ b/app/assets/javascripts/angular/services/analyticsService.js
@@ -1,4 +1,6 @@
-angular.module('missionhubApp').factory('analyticsService', analyticsService);
+angular
+    .module('campusContactsApp')
+    .factory('analyticsService', analyticsService);
 
 function analyticsService(
     $window,

--- a/app/assets/javascripts/angular/services/asyncBindings.service.js
+++ b/app/assets/javascripts/angular/services/asyncBindings.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('asyncBindingsService', asyncBindingsService);
 
 function asyncBindingsService($injector, $q, _) {

--- a/app/assets/javascripts/angular/services/authentication.service.js
+++ b/app/assets/javascripts/angular/services/authentication.service.js
@@ -1,7 +1,7 @@
 import i18next from 'i18next';
 
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('authenticationService', authenticationService);
 
 function authenticationService(

--- a/app/assets/javascripts/angular/services/authentication.service.js
+++ b/app/assets/javascripts/angular/services/authentication.service.js
@@ -140,7 +140,9 @@ function authenticationService(
 
         if (!currentState) return;
 
-        state.hasMissionhubAccess = currentState.hasMissionhubAccess;
+        state.hasCampusContactsAccess =
+            currentState.hasCampusContactsAccess ||
+            currentState.hasMissionhubAccess; // hasMissionhubAccess can be deleted during another deployment 2 days after this one when user JWTs have expired and a sign in will happen again
         state.organization_with_missing_signatures_ids =
             currentState.organization_with_missing_signatures_ids;
         state.loggedIn = true;
@@ -150,7 +152,7 @@ function authenticationService(
 
     const setState = (person) => {
         const newState = {
-            hasMissionhubAccess: true,
+            hasCampusContactsAccess: true,
             organization_with_missing_signatures_ids: person
                 ? person.organization_with_missing_signatures_ids
                 : [],
@@ -163,7 +165,7 @@ function authenticationService(
 
     const clearState = () => {
         localStorageService.destroy('state');
-        state.hasMissionhubAccess = null;
+        state.hasCampusContactsAccess = null;
         state.organization_with_missing_signatures_ids = null;
         state.loggedIn = false;
         JsonApiDataStore.store.reset();

--- a/app/assets/javascripts/angular/services/confirmModal.service.js
+++ b/app/assets/javascripts/angular/services/confirmModal.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('confirmModalService', confirmModalService);
 
 function confirmModalService($uibModal) {
@@ -27,8 +27,8 @@ function confirmModalService($uibModal) {
                 size: 'sm',
                 template: `<div>
                     <div class="modal-header">
-                    <h3 class="modal-title" id="modal-title"> 
-                        ${options.title} 
+                    <h3 class="modal-title" id="modal-title">
+                        ${options.title}
                     </h3>
                     <a ng-click="vm.cancel()" class="close-button">
                     <ng-md-icon icon="close" size="28"></ng-md-icon>

--- a/app/assets/javascripts/angular/services/error/error.service.js
+++ b/app/assets/javascripts/angular/services/error/error.service.js
@@ -1,6 +1,6 @@
 import './errorRetryToastTemplate.directive';
 
-angular.module('missionhubApp').factory('errorService', errorService);
+angular.module('campusContactsApp').factory('errorService', errorService);
 
 function errorService($timeout, $q, $log, toaster, _) {
     var errorService = {

--- a/app/assets/javascripts/angular/services/error/errorRetryToastTemplate.directive.js
+++ b/app/assets/javascripts/angular/services/error/errorRetryToastTemplate.directive.js
@@ -1,7 +1,7 @@
 import template from './errorRetryToastTemplate.html';
 
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .directive('errorRetryToastTemplate', function () {
         return {
             template: template,

--- a/app/assets/javascripts/angular/services/facebookService.js
+++ b/app/assets/javascripts/angular/services/facebookService.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('facebookService', facebookService);
+angular.module('campusContactsApp').factory('facebookService', facebookService);
 
 function facebookService(authenticationService, envService) {
     return {

--- a/app/assets/javascripts/angular/services/geoData.service.js
+++ b/app/assets/javascripts/angular/services/geoData.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('geoDataService', geoDataService);
+angular.module('campusContactsApp').factory('geoDataService', geoDataService);
 
 function geoDataService(_) {
     return {

--- a/app/assets/javascripts/angular/services/groups.service.js
+++ b/app/assets/javascripts/angular/services/groups.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('groupsService', groupsService);
+angular.module('campusContactsApp').factory('groupsService', groupsService);
 
 function groupsService(
     $q,

--- a/app/assets/javascripts/angular/services/httpProxy.service.js
+++ b/app/assets/javascripts/angular/services/httpProxy.service.js
@@ -1,6 +1,6 @@
 import { JsonApiDataStore as JsonApiDataStoreIsolated } from 'jsonapi-datastore';
 
-angular.module('missionhubApp').factory('httpProxy', proxyService);
+angular.module('campusContactsApp').factory('httpProxy', proxyService);
 function proxyService(
     $http,
     $log,

--- a/app/assets/javascripts/angular/services/interactions.service.js
+++ b/app/assets/javascripts/angular/services/interactions.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('interactionsService', interactionsService);
 
 // This service contains action logic that is shared across components

--- a/app/assets/javascripts/angular/services/labels.service.js
+++ b/app/assets/javascripts/angular/services/labels.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('labelsService', labelsService);
+angular.module('campusContactsApp').factory('labelsService', labelsService);
 
 function labelsService(httpProxy, JsonApiDataStore, modelsService, _) {
     var labelsService = {

--- a/app/assets/javascripts/angular/services/localStorage.service.js
+++ b/app/assets/javascripts/angular/services/localStorage.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').service('localStorageService', () => {
+angular.module('campusContactsApp').service('localStorageService', () => {
     const storage = {
         set: (key, value) => {
             localStorage.setItem(key, angular.toJson(value));

--- a/app/assets/javascripts/angular/services/loggedInPerson.service.js
+++ b/app/assets/javascripts/angular/services/loggedInPerson.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('loggedInPerson', loggedInPerson);
+angular.module('campusContactsApp').factory('loggedInPerson', loggedInPerson);
 
 function loggedInPerson(
     httpProxy,

--- a/app/assets/javascripts/angular/services/ministryViewTabs.service.js
+++ b/app/assets/javascripts/angular/services/ministryViewTabs.service.js
@@ -8,6 +8,6 @@ const ministryViewTabs = [
     'labels',
 ];
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .constant('ministryViewTabs', ministryViewTabs)
     .constant('ministryViewDefaultTab', ministryViewTabs[0]);

--- a/app/assets/javascripts/angular/services/models.service.js
+++ b/app/assets/javascripts/angular/services/models.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('modelsService', modelsService);
+angular.module('campusContactsApp').factory('modelsService', modelsService);
 
 function modelsService(_) {
     function generateUrls(root, extras) {

--- a/app/assets/javascripts/angular/services/organization.service.js
+++ b/app/assets/javascripts/angular/services/organization.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('organizationService', organizationService);
 
 function organizationService(

--- a/app/assets/javascripts/angular/services/peopleSearch.service.js
+++ b/app/assets/javascripts/angular/services/peopleSearch.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('peopleSearchService', peopleSearchService);
 
 function peopleSearchService(httpProxy, modelsService) {

--- a/app/assets/javascripts/angular/services/period.service.js
+++ b/app/assets/javascripts/angular/services/period.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('periodService', periodService);
+angular.module('campusContactsApp').factory('periodService', periodService);
 
 // This service contains action logic that is shared across components
 function periodService($window, $rootScope) {

--- a/app/assets/javascripts/angular/services/permission.service.js
+++ b/app/assets/javascripts/angular/services/permission.service.js
@@ -1,4 +1,6 @@
-angular.module('missionhubApp').factory('permissionService', permissionService);
+angular
+    .module('campusContactsApp')
+    .factory('permissionService', permissionService);
 
 // This service contains action logic that is shared across components
 function permissionService() {

--- a/app/assets/javascripts/angular/services/person.service.js
+++ b/app/assets/javascripts/angular/services/person.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('personService', personService);
+angular.module('campusContactsApp').factory('personService', personService);
 
 function personService(
     httpProxy,

--- a/app/assets/javascripts/angular/services/personSelection.js
+++ b/app/assets/javascripts/angular/services/personSelection.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('personSelectionService', personSelectionService);
 
 function personSelectionService(_) {

--- a/app/assets/javascripts/angular/services/personTabs.service.js
+++ b/app/assets/javascripts/angular/services/personTabs.service.js
@@ -1,5 +1,5 @@
 var personTabs = ['profile', 'history', 'assigned', 'activity'];
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .constant('personTabs', personTabs)
     .constant('personDefaultTab', personTabs[0]);

--- a/app/assets/javascripts/angular/services/progressiveListLoader.service.js
+++ b/app/assets/javascripts/angular/services/progressiveListLoader.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('ProgressiveListLoader', progressiveListLoader);
 
 function progressiveListLoader(httpProxy, modelsService, _) {

--- a/app/assets/javascripts/angular/services/reports.service.js
+++ b/app/assets/javascripts/angular/services/reports.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('reportsService', reportsService);
+angular.module('campusContactsApp').factory('reportsService', reportsService);
 
 // This service contains action logic that is shared across components
 function reportsService(

--- a/app/assets/javascripts/angular/services/requestDeduper.service.js
+++ b/app/assets/javascripts/angular/services/requestDeduper.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('RequestDeduper', requestDeduper);
+angular.module('campusContactsApp').factory('RequestDeduper', requestDeduper);
 
 function requestDeduper($q, _) {
     /*

--- a/app/assets/javascripts/angular/services/routes.service.js
+++ b/app/assets/javascripts/angular/services/routes.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('routesService', routesService);
+angular.module('campusContactsApp').factory('routesService', routesService);
 
 // This service contains logic used by the routes
 function routesService(httpProxy, modelsService) {

--- a/app/assets/javascripts/angular/services/sessionStorage.service.js
+++ b/app/assets/javascripts/angular/services/sessionStorage.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').service('sessionStorageService', () => {
+angular.module('campusContactsApp').service('sessionStorageService', () => {
     const storage = {
         set: (key, value) => {
             sessionStorage.setItem(key, angular.toJson(value));

--- a/app/assets/javascripts/angular/services/state.service.js
+++ b/app/assets/javascripts/angular/services/state.service.js
@@ -1,4 +1,4 @@
-angular.module('missionhubApp').factory('state', stateService);
+angular.module('campusContactsApp').factory('state', stateService);
 
 function stateService() {
     var service = {

--- a/app/assets/javascripts/angular/services/survey.service.js
+++ b/app/assets/javascripts/angular/services/survey.service.js
@@ -378,4 +378,4 @@ function surveyService(
     };
 }
 
-angular.module('missionhubApp').factory('surveyService', surveyService);
+angular.module('campusContactsApp').factory('surveyService', surveyService);

--- a/app/assets/javascripts/angular/services/urlHashParserService.js
+++ b/app/assets/javascripts/angular/services/urlHashParserService.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('urlHashParserService', urlHashParserService);
 
 function urlHashParserService($location) {

--- a/app/assets/javascripts/angular/services/userPreferences.service.js
+++ b/app/assets/javascripts/angular/services/userPreferences.service.js
@@ -1,5 +1,5 @@
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .factory('userPreferencesService', userPreferencesService);
 
 function userPreferencesService(httpProxy, modelsService, loggedInPerson, _) {

--- a/app/components/authentication/authLanding.component.js
+++ b/app/components/authentication/authLanding.component.js
@@ -1,5 +1,5 @@
 import template from './authLanding.html';
 
-angular.module('missionhubApp').component('authLanding', {
+angular.module('campusContactsApp').component('authLanding', {
     template: template,
 });

--- a/app/components/authentication/impersonateUser.component.js
+++ b/app/components/authentication/impersonateUser.component.js
@@ -1,6 +1,6 @@
 import template from './impersonateUser.html';
 
-angular.module('missionhubApp').component('impersonateUser', {
+angular.module('campusContactsApp').component('impersonateUser', {
     controller: impersonatePersonController,
     template: template,
     bindings: {

--- a/app/components/authentication/inviteLink.component.js
+++ b/app/components/authentication/inviteLink.component.js
@@ -1,6 +1,6 @@
 import template from './inviteLink.html';
 
-angular.module('missionhubApp').component('inviteLink', {
+angular.module('campusContactsApp').component('inviteLink', {
     controller: inviteLinkController,
     template: template,
     bindings: {

--- a/app/components/authentication/mergeAccount.component.js
+++ b/app/components/authentication/mergeAccount.component.js
@@ -1,6 +1,6 @@
 import template from './mergeAccount.html';
 
-angular.module('missionhubApp').component('mergeAccount', {
+angular.module('campusContactsApp').component('mergeAccount', {
     controller: mergeAccountController,
     template: template,
     bindings: {

--- a/app/components/authentication/signIn.component.js
+++ b/app/components/authentication/signIn.component.js
@@ -19,10 +19,6 @@ function signInController(
     sessionStorageService,
 ) {
     this.showLogin = false;
-    // eslint-disable-next-line angular/document-service
-    this.showRedirectMessage = document.referrer.match(
-        /^https:\/\/([a-zA-Z0-9-_]+\.)?missionhub.com(\/.*)?$/,
-    );
     this.facebookService = facebookService;
     this.campusContactsLogo = campusContactsLogo;
 

--- a/app/components/authentication/signIn.component.js
+++ b/app/components/authentication/signIn.component.js
@@ -3,7 +3,7 @@ import campusContactsLogo from '../../assets/images/favicon.svg';
 import template from './signIn.html';
 import './signIn.scss';
 
-angular.module('missionhubApp').component('signIn', {
+angular.module('campusContactsApp').component('signIn', {
     controller: signInController,
     template: template,
     bindings: {

--- a/app/components/authentication/signIn.html
+++ b/app/components/authentication/signIn.html
@@ -34,24 +34,4 @@
             {{ 'login.continueWithFacebook' | t }}
         </a>
     </div>
-
-    <div
-        class="m-auto tl measure ba pa3 br3 bg-pivot-white ma3"
-        ng-if="$ctrl.showRedirectMessage"
-    >
-        <h2 class="ttu mt0">
-            Hey, how did I get here?
-        </h2>
-        <p>
-            MissionHub has split into two products. The web based Campus
-            Contacts now serves your campus ministry contact management needs.
-        </p>
-        <p>
-            Be sure to bookmark this new page.
-        </p>
-        <p class="mb0">
-            And don't worry, all your ministries and people have been brought
-            over for you.
-        </p>
-    </div>
 </div>

--- a/app/components/navigation/navHeader.component.js
+++ b/app/components/navigation/navHeader.component.js
@@ -5,7 +5,7 @@ import template from './navHeader.html';
 import './navHeader.scss';
 import './navSearch.component';
 
-angular.module('missionhubApp').component('navHeader', {
+angular.module('campusContactsApp').component('navHeader', {
     controller: navHeaderController,
     template: template,
     bindings: {

--- a/app/components/navigation/navHeader.html
+++ b/app/components/navigation/navHeader.html
@@ -3,7 +3,7 @@
 >
     <ul
         class="font-titillium ml0 pl0 mb0 list fade w-40-ns"
-        ng-if="!$ctrl.hideMenuLinks && $ctrl.state.hasMissionhubAccess && $ctrl.state.loggedIn"
+        ng-if="!$ctrl.hideMenuLinks && $ctrl.state.hasCampusContactsAccess && $ctrl.state.loggedIn"
         id="primary_nav"
     >
         <li
@@ -33,7 +33,7 @@
     </a>
     <span
         class="flex w-25 items-center justify-end content-end fade w-40-ns"
-        ng-if="!$ctrl.hideMenuLinks && $ctrl.state.hasMissionhubAccess && $ctrl.state.loggedIn"
+        ng-if="!$ctrl.hideMenuLinks && $ctrl.state.hasCampusContactsAccess && $ctrl.state.loggedIn"
     >
         <a href ng-click="$ctrl.toggleSearchBar()">
             <img ng-src="{{ $ctrl.searchIcon }}" />
@@ -87,7 +87,7 @@
     <ul
         class="list fade"
         id="primary_nav"
-        ng-if="!$ctrl.hideMenuLinks && !$ctrl.state.hasMissionhubAccess && $ctrl.state.loggedIn"
+        ng-if="!$ctrl.hideMenuLinks && !$ctrl.state.hasCampusContactsAccess && $ctrl.state.loggedIn"
     >
         <li class="fl">
             <a href class="pivot-white f4 mr2" ng-click="$ctrl.logout()"

--- a/app/components/navigation/navSearch.component.js
+++ b/app/components/navigation/navSearch.component.js
@@ -1,7 +1,7 @@
 import template from './navSearch.html';
 import './navSearch.scss';
 
-angular.module('missionhubApp').component('navSearch', {
+angular.module('campusContactsApp').component('navSearch', {
     controller: navSearchController,
     template: template,
 });

--- a/index.ejs
+++ b/index.ejs
@@ -42,7 +42,7 @@
     <body
         class="bg-pivot-gray"
         ng-cloak
-        ng-app="missionhubApp"
+        ng-app="campusContactsApp"
         ng-class="{
             'overflow-hidden-s': $root.showPeopleFilters
         }"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "1.0.0",
     "scripts": {
         "start": "webpack-dev-server",
-        "start-rails-api": "cd ../missionhub-api && rails s",
+        "start-rails-api": "cd ../campus-contacts-api && rails s",
         "build": "webpack -p",
         "build:analyze": "webpack -p --env.analyze",
         "gql:schema": "apollo client:download-schema",

--- a/src/communityInsights/insights.tsx
+++ b/src/communityInsights/insights.tsx
@@ -30,7 +30,7 @@ const Insights = ({ orgId, authenticationService }: Props) => {
 };
 
 // @ts-ignore
-angular.module('missionhubApp').component(
+angular.module('campusContactsApp').component(
     'insights',
     // @ts-ignore
     react2angular(Insights, ['orgId'], ['authenticationService']),

--- a/src/graphqlPlayground/GraphqlPlaygroundLazy.tsx
+++ b/src/graphqlPlayground/GraphqlPlaygroundLazy.tsx
@@ -21,7 +21,7 @@ const GraphqlPlaygroundLoader = (props: GraphqlPlaygroundProps) => (
 );
 
 angular
-    .module('missionhubApp')
+    .module('campusContactsApp')
     .component(
         'graphqlPlayground',
         react2angular(GraphqlPlaygroundLoader, null, [

--- a/src/i18n/locales/en-US.js
+++ b/src/i18n/locales/en-US.js
@@ -616,7 +616,7 @@ export default {
                         'Next to the webhooks title click the slider to enable webhooks.',
                     conclusion:
                         'Future form submissions for this survey will be sent to Campus Contacts automatically.',
-                    missionHubUrl: 'Campus Contacts URL',
+                    campusContactsUrl: 'Campus Contacts URL',
                     copy: 'Copy URL',
                     copied: 'URL copied to clipboard',
                 },


### PR DESCRIPTION
None of this config happened in the PR but I also renamed the repo, made master and staging the default branches again, and reconfigured Amplify to host the new repo and branches. I also stopped hosting anything related to MissionHub on Amplify since the main domains have all been moved to Wordpress.

I'll try and extract all the React stuff to a new repo in another PR so there are still a few MissionHub strings in the repo until that's completed.

This is probably easier to review by commit. The module rename touched a lot of files.