### PR TITLE
Improve-Required-Survey-Fields

### DIFF
--- a/app/assets/javascripts/angular/components/surveys/surveyFormPublic.html
+++ b/app/assets/javascripts/angular/components/surveys/surveyFormPublic.html
@@ -12,7 +12,9 @@
             ng-repeat="question in $ctrl.surveyQuestions track by question.id"
         >
             <label class="pivot-gray-darker f3 mb3 db"
-                >{{question.label}}</label
+                >{{question.label}}<span class="red"
+                    >{{question.required ? '*' : ''}}</span
+                ></label
             >
 
             <div ng-switch="question.kind">

--- a/app/assets/javascripts/angular/components/surveys/surveyFormUser.html
+++ b/app/assets/javascripts/angular/components/surveys/surveyFormUser.html
@@ -11,7 +11,11 @@
             class="mv3"
             ng-repeat="question in $ctrl.surveyQuestions track by question.id"
         >
-            <label class="pivot-gray-darker mb1 db">{{question.label}}</label>
+            <label class="pivot-gray-darker mb1 db"
+                >{{question.label}}<span class="red"
+                    >{{question.required ? '*' : ''}}</span
+                ></label
+            >
 
             <div ng-switch="question.kind">
                 <div ng-switch-when="ChoiceField" ng-switch="question.style">


### PR DESCRIPTION
Helpscout ticket: https://secure.helpscout.net/conversation/1757456528/695147?folderId=3233957 

While this doesn't specifically fix the issue of the helpscout ticket, I figured a better visual indicator of a required field would be an improvement from a UX standpoint. After investigating and talking with @dbenton9, the issue in the HS ticket is API related, as the api should return an error if those fields are blank like it does for ```first name```.